### PR TITLE
Added index as part of key

### DIFF
--- a/components/About/MissionVision.tsx
+++ b/components/About/MissionVision.tsx
@@ -1,47 +1,47 @@
-import React from "react";
-import { Container } from "react-bootstrap";
-import Row from "react-bootstrap/Row";
-import BibleVerse from "./BibleVerse";
-import { useTranslation } from "next-i18next";
+import React from "react"
+import { Container } from "react-bootstrap"
+import Row from "react-bootstrap/Row"
+import BibleVerse from "./BibleVerse"
+import { useTranslation } from "next-i18next"
 
 const MissionVision: React.FC = () => {
-    const { t } = useTranslation("about");
-    const missionStatements: string[] = t("mission.content", { returnObjects: true });
-    const missionMap: string[] = Array.isArray(missionStatements) ? missionStatements : [];
+  const { t } = useTranslation("about")
+  const missionStatements: string[] = t("mission.content", { returnObjects: true })
+  const missionMap: string[] = Array.isArray(missionStatements) ? missionStatements : []
 
-    const visionStatements: string[] = t("vision.content", { returnObjects: true });
-    const visionMap: string[] = Array.isArray(visionStatements) ? visionStatements : [];
+  const visionStatements: string[] = t("vision.content", { returnObjects: true })
+  const visionMap: string[] = Array.isArray(visionStatements) ? visionStatements : []
 
-    return (
-        <section id="mission-vision-section" data-testid="mission-vision-section" className="position-relative">
-            <Container id="mission-vision" className="py-5">
-                <div id="about-landing-image" className="w-100 p-3">
-                    temporary image placeholder
-                </div>
-                <Container className="d-flex flex-wrap justify-content-center align-items-center p-4">
-                    <Row md={2} sm={1}>
-                        <Container>
-                            <h4>{t("mission.title")}</h4>
-                            {missionMap.map((text: string) => (
-                                <p key={text} className="fs-6">
-                                    {text}
-                                </p>
-                            ))}
-                        </Container>
-                        <Container>
-                            <h4>{t("vision.title")}</h4>
-                            {visionMap.map((text: string) => (
-                                <p key={text} className="fs-6">
-                                    {text}
-                                </p>
-                            ))}
-                        </Container>
-                    </Row>
-                </Container>
-                <BibleVerse content={t("bible.content")} passageLocation={t("bible.passageLocation")} />
+  return (
+    <section id="mission-vision-section" data-testid="mission-vision-section" className="position-relative">
+      <Container id="mission-vision" className="py-5">
+        <div id="about-landing-image" className="w-100 p-3">
+          temporary image placeholder
+        </div>
+        <Container className="d-flex flex-wrap justify-content-center align-items-center p-4">
+          <Row md={2} sm={1}>
+            <Container>
+              <h4>{t("mission.title")}</h4>
+              {missionMap.map((text: string, idx: number) => (
+                <p key={idx + text} className="fs-6">
+                  {text}
+                </p>
+              ))}
             </Container>
-        </section>
-    );
-};
+            <Container>
+              <h4>{t("vision.title")}</h4>
+              {visionMap.map((text: string, idx: number) => (
+                <p key={idx + text} className="fs-6">
+                  {text}
+                </p>
+              ))}
+            </Container>
+          </Row>
+        </Container>
+        <BibleVerse content={t("bible.content")} passageLocation={t("bible.passageLocation")} />
+      </Container>
+    </section>
+  )
+}
 
-export default MissionVision;
+export default MissionVision

--- a/components/About/WhyTheName.tsx
+++ b/components/About/WhyTheName.tsx
@@ -1,30 +1,30 @@
-import React from "react";
-import { useTranslation } from "next-i18next";
-import { Container } from "react-bootstrap";
+import React from "react"
+import { useTranslation } from "next-i18next"
+import { Container } from "react-bootstrap"
 
 const WhyTheName: React.FC = () => {
-    const { t } = useTranslation("about");
-    const nameExplanations: string[] = t("why.content", { returnObjects: true });
-    const nameMap: string[] = Array.isArray(nameExplanations) ? nameExplanations : [];
+  const { t } = useTranslation("about")
+  const nameExplanations: string[] = t("why.content", { returnObjects: true })
+  const nameMap: string[] = Array.isArray(nameExplanations) ? nameExplanations : []
 
-    return (
-        <section id="why-the-name-section" data-testid="why-the-name-section" className="position-relative">
-            <Container id="why-the-name" className="py-4">
-                <div id="about-landing-image" className="w-100 mx-0 px-0 my-4">
-                    temporary image placeholder
-                </div>
-                <Container className="why-content mt-5">
-                    <h4 className="my-3">{t("why.title")}</h4>
-                    {nameMap.map((text: string) => (
-                        <p key={text} className="fs-6">
-                            {text}
-                        </p>
-                    ))}
-                </Container>
-                <div className="why-bar mt-5"></div>
-            </Container>
-        </section>
-    );
-};
+  return (
+    <section id="why-the-name-section" data-testid="why-the-name-section" className="position-relative">
+      <Container id="why-the-name" className="py-4">
+        <div id="about-landing-image" className="w-100 mx-0 px-0 my-4">
+          temporary image placeholder
+        </div>
+        <Container className="why-content mt-5">
+          <h4 className="my-3">{t("why.title")}</h4>
+          {nameMap.map((text: string, idx: number) => (
+            <p key={idx + text} className="fs-6">
+              {text}
+            </p>
+          ))}
+        </Container>
+        <div className="why-bar mt-5"></div>
+      </Container>
+    </section>
+  )
+}
 
-export default WhyTheName;
+export default WhyTheName

--- a/components/common/PrayerPoints.tsx
+++ b/components/common/PrayerPoints.tsx
@@ -1,64 +1,83 @@
-import React from "react";
-import { Container, Card } from "react-bootstrap";
-import {FaPrayingHands} from 'react-icons/fa'
-import { IconContext } from "react-icons/lib";
-import { BsDownload } from "react-icons/bs";
-import Button from "react-bootstrap/Button";
-import { useTranslation } from "next-i18next";
+import React from "react"
+import { Container, Card } from "react-bootstrap"
+import { FaPrayingHands } from "react-icons/fa"
+import { IconContext } from "react-icons/lib"
+import { BsDownload } from "react-icons/bs"
+import Button from "react-bootstrap/Button"
+import { useTranslation } from "next-i18next"
 
 interface prayerProps {
-    prayerPoints: string[] // array of prayer points
-    title: string // Title that goes on top of card
-    featured?: boolean // is this component the "featured" component?
-    showImg?: boolean // show the image?
-    showSubtitle?: boolean // show the "Pray For" subtitle?
+  prayerPoints: string[] // array of prayer points
+  title: string // Title that goes on top of card
+  featured?: boolean // is this component the "featured" component?
+  showImg?: boolean // show the image?
+  showSubtitle?: boolean // show the "Pray For" subtitle?
 }
 
+export default function PrayerPoints({
+  prayerPoints,
+  title,
+  featured = false,
+  showImg = false,
+  showSubtitle = false,
+}: prayerProps) {
+  const { t } = useTranslation("common")
 
-export default function PrayerPoints({prayerPoints, title, featured=false, showImg=false, showSubtitle=false}:prayerProps) {
+  const subtitle: string = t("prayerSummary.subtitle")
+  const view: string = t("prayerSummary.view")
+  const read: string = t("prayerSummary.read")
 
-    const { t } = useTranslation("common");
-
-    const subtitle:string = t("prayerSummary.subtitle")
-    const view:string = t("prayerSummary.view")
-    const read:string = t("prayerSummary.read")
-
-    return (
-        <Container data-testid={"prayer-points-container"} className={"d-flex px-6" + (showSubtitle ? " justify-content-center" : " justify-content-start")} id="topic-prayer">
-            <Card className="my-4 shadow d-lg-flex flex-lg-row">
-                {/* temporary height for video, before we finalize videos */}
-                {showImg &&
-                    <Card.Img className='h-100' variant="top" src="/bamboo.jpeg" style={{maxWidth:'600px'}}></Card.Img>
-                }
-                <Card.Body style={showSubtitle ? {maxWidth:'600px'} : {maxWidth: '400px'}}>
-                    <Card.Text data-testid={"prayer-points-title"} className="px-2 pb-3 fs-2 fst-italic fw-bold border-bottom border-grey d-flex justify-content-between align-items-center">
-                        {title}
-                        <IconContext.Provider value={{size:'30px'}}>
-                            <BsDownload className="text-secondary fw-bold" style={{cursor: 'pointer'}}>
-                            </BsDownload>
-                        </IconContext.Provider>
-                    </Card.Text>
-                    {showSubtitle && 
-                        <Card.Text className="d-flex align-items-center gap-2 text-secondary">
-                            <IconContext.Provider value={{size:'20px'}}>
-                                <FaPrayingHands></FaPrayingHands>
-                            </IconContext.Provider>
-                            {subtitle}
-                        </Card.Text>
-                    }
-                    <ul className="fs-5" data-testid={"prayer-points-points"}>
-                        {prayerPoints.map((point:string) => 
-                            <li key={point} className="my-3">{point}</li>
-                        )}
-                    </ul>
-                    {featured && <>
-                        <Button className="w-100 mt-2 text-secondary border-secondary bg-white" variant="primary">{read}</Button>
-                        <Card.Text className="my-3 w-100 mx-auto text-center text-decoration-underline text-secondary" style={{cursor:"pointer"}}>
-                            {view}
-                        </Card.Text>
-                    </>}
-                </Card.Body>
-            </Card>
-        </Container>
-    )
+  return (
+    <Container
+      data-testid={"prayer-points-container"}
+      className={"d-flex px-6" + (showSubtitle ? " justify-content-center" : " justify-content-start")}
+      id="topic-prayer"
+    >
+      <Card className="my-4 shadow d-lg-flex flex-lg-row">
+        {/* temporary height for video, before we finalize videos */}
+        {showImg && (
+          <Card.Img className="h-100" variant="top" src="/bamboo.jpeg" style={{ maxWidth: "600px" }}></Card.Img>
+        )}
+        <Card.Body style={showSubtitle ? { maxWidth: "600px" } : { maxWidth: "400px" }}>
+          <Card.Text
+            data-testid={"prayer-points-title"}
+            className="px-2 pb-3 fs-2 fst-italic fw-bold border-bottom border-grey d-flex justify-content-between align-items-center"
+          >
+            {title}
+            <IconContext.Provider value={{ size: "30px" }}>
+              <BsDownload className="text-secondary fw-bold" style={{ cursor: "pointer" }}></BsDownload>
+            </IconContext.Provider>
+          </Card.Text>
+          {showSubtitle && (
+            <Card.Text className="d-flex align-items-center gap-2 text-secondary">
+              <IconContext.Provider value={{ size: "20px" }}>
+                <FaPrayingHands></FaPrayingHands>
+              </IconContext.Provider>
+              {subtitle}
+            </Card.Text>
+          )}
+          <ul className="fs-5" data-testid={"prayer-points-points"}>
+            {prayerPoints.map((point: string, idx: number) => (
+              <li key={idx + point} className="my-3">
+                {point}
+              </li>
+            ))}
+          </ul>
+          {featured && (
+            <>
+              <Button className="w-100 mt-2 text-secondary border-secondary bg-white" variant="primary">
+                {read}
+              </Button>
+              <Card.Text
+                className="my-3 w-100 mx-auto text-center text-decoration-underline text-secondary"
+                style={{ cursor: "pointer" }}
+              >
+                {view}
+              </Card.Text>
+            </>
+          )}
+        </Card.Body>
+      </Card>
+    </Container>
+  )
 }

--- a/components/landing/FeaturedTopic.tsx
+++ b/components/landing/FeaturedTopic.tsx
@@ -1,42 +1,47 @@
-import React from "react";
-import { Container, Card } from "react-bootstrap";
-import {FaPrayingHands} from 'react-icons/fa'
-import { IconContext } from "react-icons/lib";
-import Button from "react-bootstrap/Button";
+import React from "react"
+import { Container, Card } from "react-bootstrap"
+import { FaPrayingHands } from "react-icons/fa"
+import { IconContext } from "react-icons/lib"
+import Button from "react-bootstrap/Button"
 
 interface Props {
-    title: string
-    prayerPoints: string[]
-    subtitle: string
+  title: string
+  prayerPoints: string[]
+  subtitle: string
 }
 
-export default function FeaturedTopic({title, prayerPoints, subtitle}:Props) {
-    return (
-        <Container className="d-flex justify-content-center">
-            <Card className="my-4 shadow d-lg-flex flex-lg-row">
-                {/* temporary height for image, before we finalize images */}
-                <Card.Img variant="top" src="/bamboo.jpeg" style={{height:'300px', maxWidth: '600px'}}></Card.Img>
-                <Card.Body style={{maxWidth: '600px'}}>
-                    <Card.Text className="px-2 pb-3 fs-2 fst-italic fw-bold border-bottom border-grey">
-                        {title}
-                    </Card.Text>
-                    <Card.Text className="d-flex align-items-center gap-2 text-secondary">
-                        <IconContext.Provider value={{size:'20px'}}>
-                            <FaPrayingHands></FaPrayingHands>
-                        </IconContext.Provider>
-                        {subtitle}
-                    </Card.Text>
-                    <ul className="fs-5">
-                        {prayerPoints.map((point:string) => 
-                            <li key={point} className="my-3">{point}</li>
-                        )}
-                    </ul>
-                    <Button className="w-100 mt-2 text-secondary border-secondary bg-white" variant="primary">Read the entire article</Button>
-                    <Card.Text className="my-3 w-100 mx-auto text-center text-decoration-underline text-secondary" style={{cursor:"pointer"}}>
-                        View all topics
-                    </Card.Text>
-                </Card.Body>
-            </Card>
-        </Container>
-    )
+export default function FeaturedTopic({ title, prayerPoints, subtitle }: Props) {
+  return (
+    <Container className="d-flex justify-content-center">
+      <Card className="my-4 shadow d-lg-flex flex-lg-row">
+        {/* temporary height for image, before we finalize images */}
+        <Card.Img variant="top" src="/bamboo.jpeg" style={{ height: "300px", maxWidth: "600px" }}></Card.Img>
+        <Card.Body style={{ maxWidth: "600px" }}>
+          <Card.Text className="px-2 pb-3 fs-2 fst-italic fw-bold border-bottom border-grey">{title}</Card.Text>
+          <Card.Text className="d-flex align-items-center gap-2 text-secondary">
+            <IconContext.Provider value={{ size: "20px" }}>
+              <FaPrayingHands></FaPrayingHands>
+            </IconContext.Provider>
+            {subtitle}
+          </Card.Text>
+          <ul className="fs-5">
+            {prayerPoints.map((point: string, idx: number) => (
+              <li key={idx + point} className="my-3">
+                {point}
+              </li>
+            ))}
+          </ul>
+          <Button className="w-100 mt-2 text-secondary border-secondary bg-white" variant="primary">
+            Read the entire article
+          </Button>
+          <Card.Text
+            className="my-3 w-100 mx-auto text-center text-decoration-underline text-secondary"
+            style={{ cursor: "pointer" }}
+          >
+            View all topics
+          </Card.Text>
+        </Card.Body>
+      </Card>
+    </Container>
+  )
 }

--- a/components/topic/PrayerSummary.tsx
+++ b/components/topic/PrayerSummary.tsx
@@ -1,33 +1,37 @@
-import React from "react";
-import { Container, Card } from "react-bootstrap";
-import {FaPrayingHands} from 'react-icons/fa'
-import { IconContext } from "react-icons/lib";
-import { BsDownload } from "react-icons/bs";
+import React from "react"
+import { Container, Card } from "react-bootstrap"
+import { FaPrayingHands } from "react-icons/fa"
+import { IconContext } from "react-icons/lib"
+import { BsDownload } from "react-icons/bs"
 
 interface summaryProps {
-    prayerPoints: string[]
-    title: string
+  prayerPoints: string[]
+  title: string
 }
 
-export default function PrayerSummary({prayerPoints, title}:summaryProps) {
-    return (
-        <Container data-testid={"prayer-summary-container"} className="d-flex px-6 justify-content-start">
-            <Card className="my-4 shadow" style={{maxWidth: '400px'}}>
-                <Card.Body>
-                    <Card.Text data-testid={"prayer-summary-title"} className="text-primary px-2 py-3 fs-4 fst-italic border-bottom border-grey d-flex justify-content-between align-items-center">
-                        {title}
-                        <IconContext.Provider value={{size:'20px'}}>
-                            <BsDownload className="text-secondary fw-bold" style={{cursor: 'pointer'}}>
-                            </BsDownload>
-                        </IconContext.Provider>
-                    </Card.Text>
-                    <ul className="fs-5" data-testid={"prayer-summary-points"}>
-                        {prayerPoints.map((point:string) => 
-                            <li key={point} className="my-3 fs-6">{point}</li>
-                        )}
-                    </ul>
-                </Card.Body>
-            </Card>
-        </Container>
-    )
+export default function PrayerSummary({ prayerPoints, title }: summaryProps) {
+  return (
+    <Container data-testid={"prayer-summary-container"} className="d-flex px-6 justify-content-start">
+      <Card className="my-4 shadow" style={{ maxWidth: "400px" }}>
+        <Card.Body>
+          <Card.Text
+            data-testid={"prayer-summary-title"}
+            className="text-primary px-2 py-3 fs-4 fst-italic border-bottom border-grey d-flex justify-content-between align-items-center"
+          >
+            {title}
+            <IconContext.Provider value={{ size: "20px" }}>
+              <BsDownload className="text-secondary fw-bold" style={{ cursor: "pointer" }}></BsDownload>
+            </IconContext.Provider>
+          </Card.Text>
+          <ul className="fs-5" data-testid={"prayer-summary-points"}>
+            {prayerPoints.map((point: string, idx: number) => (
+              <li key={idx + point} className="my-3 fs-6">
+                {point}
+              </li>
+            ))}
+          </ul>
+        </Card.Body>
+      </Card>
+    </Container>
+  )
 }

--- a/components/topic/RelatedContent.tsx
+++ b/components/topic/RelatedContent.tsx
@@ -1,117 +1,123 @@
-import Link from "next/link";
-import React from "react";
-import { Card, Container, Carousel } from "react-bootstrap";
+import Link from "next/link"
+import React from "react"
+import { Card, Container, Carousel } from "react-bootstrap"
 
 interface relatedProps {
-    topics: string[]
-    links: string[]
-    title?: string
+  topics: string[]
+  links: string[]
+  title?: string
 }
 
-export default function RelatedContent({topics, links, title}:relatedProps) {
-    return (
-        <Container data-testid={"related-content-container"} className="d-flex flex-column my-5">
-            <Container className="d-flex flex-row justify-content-between align-items-center">
-                <h1 data-testid={"related-content-title"} className="text-primary my-4 fs-1">{title}</h1>
-                <a href={'/topics'} className="text-secondary d-none d-md-block">View all topics</a>
-            </Container>
-            <CarouselSmall topics={topics} links={links}/>
-            <CarouselLarge topics={topics} links={links}/>
-            <a href={'/topics'} className="align-self-center my-3 text-secondary d-md-none">View all topics</a>
-        </Container>
-    )
+export default function RelatedContent({ topics, links, title }: relatedProps) {
+  return (
+    <Container data-testid={"related-content-container"} className="d-flex flex-column my-5">
+      <Container className="d-flex flex-row justify-content-between align-items-center">
+        <h1 data-testid={"related-content-title"} className="text-primary my-4 fs-1">
+          {title}
+        </h1>
+        <a href={"/topics"} className="text-secondary d-none d-md-block">
+          View all topics
+        </a>
+      </Container>
+      <CarouselSmall topics={topics} links={links} />
+      <CarouselLarge topics={topics} links={links} />
+      <a href={"/topics"} className="align-self-center my-3 text-secondary d-md-none">
+        View all topics
+      </a>
+    </Container>
+  )
 }
 
-function CarouselSmall({topics, links}:relatedProps) {
-    return (
-        <Carousel indicators={false} interval={null} className="d-md-none">
-            <Carousel.Item>
-                    <div data-testid={"related-content-links"} className="d-flex justify-content-around gap-2">
-                    {topics.slice(0,2).map((topic, idx) => 
-                        <Link href={links[idx]} key={topic}>
-                            <Card style={{width: "308px", height: "186px"}} key={topic}>
-                                <Card.Body className="m-0 p-0">
-                                    <div className="w-100 bg-secondary" style={{height: "138px"}}></div>
-                                </Card.Body>
-                                <Card.Body className="m-2 p-1">
-                                    <p>{topic}</p>
-                                </Card.Body>
-                            </Card>
-                        </Link>
-                    )}
-                    </div>
-                </Carousel.Item>
-                <Carousel.Item>
-                    <div className="d-flex justify-content-around gap-2">
-                    {topics.slice(2,4).map((topic, idx) => 
-                        <Link href={links[idx]} key={topic}>
-                            <Card style={{width: "308px", height: "186px"}} key={topic}>
-                                <Card.Body className="m-0 p-0">
-                                    <div className="w-100 bg-secondary" style={{height: "138px"}}></div>
-                                </Card.Body>
-                                <Card.Body className="m-2 p-1">
-                                    <p>{topic}</p>
-                                </Card.Body>
-                            </Card>
-                        </Link>
-                    )}
-                    </div>
-                </Carousel.Item>
-                <Carousel.Item>
-                    <div className="d-flex justify-content-around gap-2">
-                    {topics.slice(4,6).map((topic, idx) => 
-                        <Link href={links[idx]} key={topic}>
-                            <Card style={{width: "308px", height: "186px"}} key={topic}>
-                                <Card.Body className="m-0 p-0">
-                                    <div className="w-100 bg-secondary" style={{height: "138px"}}></div>
-                                </Card.Body>
-                                <Card.Body className="m-2 p-1">
-                                    <p>{topic}</p>
-                                </Card.Body>
-                            </Card>
-                        </Link>
-                    )}
-                    </div>
-                </Carousel.Item>
-        </Carousel>
-    )
+function CarouselSmall({ topics, links }: relatedProps) {
+  return (
+    <Carousel indicators={false} interval={null} className="d-md-none">
+      <Carousel.Item>
+        <div data-testid={"related-content-links"} className="d-flex justify-content-around gap-2">
+          {topics.slice(0, 2).map((topic, idx) => (
+            <Link href={links[idx]} key={idx + topic}>
+              <Card style={{ width: "308px", height: "186px" }}>
+                <Card.Body className="m-0 p-0">
+                  <div className="w-100 bg-secondary" style={{ height: "138px" }}></div>
+                </Card.Body>
+                <Card.Body className="m-2 p-1">
+                  <p>{topic}</p>
+                </Card.Body>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      </Carousel.Item>
+      <Carousel.Item>
+        <div className="d-flex justify-content-around gap-2">
+          {topics.slice(2, 4).map((topic, idx) => (
+            <Link href={links[idx]} key={idx + topic}>
+              <Card style={{ width: "308px", height: "186px" }}>
+                <Card.Body className="m-0 p-0">
+                  <div className="w-100 bg-secondary" style={{ height: "138px" }}></div>
+                </Card.Body>
+                <Card.Body className="m-2 p-1">
+                  <p>{topic}</p>
+                </Card.Body>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      </Carousel.Item>
+      <Carousel.Item>
+        <div className="d-flex justify-content-around gap-2">
+          {topics.slice(4, 6).map((topic, idx) => (
+            <Link href={links[idx]} key={idx + topic}>
+              <Card style={{ width: "308px", height: "186px" }}>
+                <Card.Body className="m-0 p-0">
+                  <div className="w-100 bg-secondary" style={{ height: "138px" }}></div>
+                </Card.Body>
+                <Card.Body className="m-2 p-1">
+                  <p>{topic}</p>
+                </Card.Body>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      </Carousel.Item>
+    </Carousel>
+  )
 }
 
-function CarouselLarge({topics, links}:relatedProps) {
-    return (
-        <Carousel indicators={false} interval={null} className="d-none d-md-block">
-                <Carousel.Item>
-                    <div data-tesid={"related-content-links"} className="d-flex justify-content-around gap-2">
-                    {topics.slice(0,4).map((topic, idx) => 
-                        <Link href={links[idx]} key={topic}>
-                            <Card style={{width: "308px", height: "186px"}} key={topic}>
-                                <Card.Body className="m-0 p-0">
-                                    <div className="w-100 bg-secondary" style={{height: "138px"}}></div>
-                                </Card.Body>
-                                <Card.Body className="m-2 p-1">
-                                    <p>{topic}</p>
-                                </Card.Body>
-                            </Card>
-                        </Link>
-                    )}
-                    </div>
-                </Carousel.Item>
-                <Carousel.Item>
-                    <div className="d-flex justify-content-around gap-2">
-                    {topics.slice(2,6).map((topic, idx) => 
-                        <Link href={links[idx]} key={topic}>
-                            <Card style={{width: "308px", height: "186px"}} key={topic}>
-                                <Card.Body className="m-0 p-0">
-                                    <div className="w-100 bg-secondary" style={{height: "138px"}}></div>
-                                </Card.Body>
-                                <Card.Body className="m-2 p-1">
-                                    <p>{topic}</p>
-                                </Card.Body>
-                            </Card>
-                        </Link>
-                    )}
-                    </div>
-                </Carousel.Item>
-            </Carousel>
-    )
+function CarouselLarge({ topics, links }: relatedProps) {
+  return (
+    <Carousel indicators={false} interval={null} className="d-none d-md-block">
+      <Carousel.Item>
+        <div data-tesid={"related-content-links"} className="d-flex justify-content-around gap-2">
+          {topics.slice(0, 4).map((topic, idx) => (
+            <Link href={links[idx]} key={idx + topic}>
+              <Card style={{ width: "308px", height: "186px" }}>
+                <Card.Body className="m-0 p-0">
+                  <div className="w-100 bg-secondary" style={{ height: "138px" }}></div>
+                </Card.Body>
+                <Card.Body className="m-2 p-1">
+                  <p>{topic}</p>
+                </Card.Body>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      </Carousel.Item>
+      <Carousel.Item>
+        <div className="d-flex justify-content-around gap-2">
+          {topics.slice(2, 6).map((topic, idx) => (
+            <Link href={links[idx]} key={idx + topic}>
+              <Card style={{ width: "308px", height: "186px" }}>
+                <Card.Body className="m-0 p-0">
+                  <div className="w-100 bg-secondary" style={{ height: "138px" }}></div>
+                </Card.Body>
+                <Card.Body className="m-2 p-1">
+                  <p>{topic}</p>
+                </Card.Body>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      </Carousel.Item>
+    </Carousel>
+  )
 }

--- a/components/topic/TopicDownloadables.tsx
+++ b/components/topic/TopicDownloadables.tsx
@@ -1,41 +1,49 @@
-import React from "react";
-import { Container, Card} from "react-bootstrap";
-import Button from "react-bootstrap/Button";
-import Row from "react-bootstrap/Row";
-import Col from "react-bootstrap/Col";
-import Link from "next/link";
+import React from "react"
+import { Container, Card } from "react-bootstrap"
+import Button from "react-bootstrap/Button"
+import Row from "react-bootstrap/Row"
+import Col from "react-bootstrap/Col"
+import Link from "next/link"
 
 interface downloadProps {
-    links: string[]
-    title: string
-    labels: string[]
-    headers: string[]
+  links: string[]
+  title: string
+  labels: string[]
+  headers: string[]
 }
 
-export default function TopicDownloadables({links, title, labels, headers}:downloadProps) {
-    return (
-        <Container data-testid={"topic-downloadables-container"} className="d-flex flex-column my-5" id="topic-downloads">
-            <Container className="d-flex flex-row justify-content-between align-items-center">
-                <h1 data-testid={"topic-downloadables-title"} className="text-primary my-4 fs-1">{title}</h1>
-                <a href={'/downloads'} className="text-secondary d-none d-md-block">{headers[0]}</a>
-            </Container>
-           <Row xl={4} lg={2} className="g-3" data-testid={"topic-downloadables-links"}>
-            {labels.map((label, idx) => 
-                 <Col key={label}>
-                    <Link href={links[idx]} className="text-decoration-none">
-                        <Card className="shadow-sm border-0 rounded" style={{backgroundColor: '#E2E2E2', minHeight: '125px'}}>
-                                <Card.Body className="d-flex align-items-center justify-content-center">
-                                    <p className="text-center fw-bold fs-4 my-0">{label}</p>
-                                </Card.Body>
-                        </Card>
-                    </Link>
-                </Col>
-            )}
-           </Row>
-            <Link href={links[4]} className="align-self-center w-100" style={{maxWidth:'500px'}}>
-                <Button className="align-self-center w-100 mt-4 text-white border-secondary bg-secondary" variant="primary">{headers[1]}</Button>
+export default function TopicDownloadables({ links, title, labels, headers }: downloadProps) {
+  return (
+    <Container data-testid={"topic-downloadables-container"} className="d-flex flex-column my-5" id="topic-downloads">
+      <Container className="d-flex flex-row justify-content-between align-items-center">
+        <h1 data-testid={"topic-downloadables-title"} className="text-primary my-4 fs-1">
+          {title}
+        </h1>
+        <a href={"/downloads"} className="text-secondary d-none d-md-block">
+          {headers[0]}
+        </a>
+      </Container>
+      <Row xl={4} lg={2} className="g-3" data-testid={"topic-downloadables-links"}>
+        {labels.map((label, idx) => (
+          <Col key={idx + label}>
+            <Link href={links[idx]} className="text-decoration-none">
+              <Card className="shadow-sm border-0 rounded" style={{ backgroundColor: "#E2E2E2", minHeight: "125px" }}>
+                <Card.Body className="d-flex align-items-center justify-content-center">
+                  <p className="text-center fw-bold fs-4 my-0">{label}</p>
+                </Card.Body>
+              </Card>
             </Link>
-            <a href={'/downloads'} className="align-self-center my-3 text-secondary d-md-none">{headers[0]}</a>
-        </Container>
-    )
+          </Col>
+        ))}
+      </Row>
+      <Link href={links[4]} className="align-self-center w-100" style={{ maxWidth: "500px" }}>
+        <Button className="align-self-center w-100 mt-4 text-white border-secondary bg-secondary" variant="primary">
+          {headers[1]}
+        </Button>
+      </Link>
+      <a href={"/downloads"} className="align-self-center my-3 text-secondary d-md-none">
+        {headers[0]}
+      </a>
+    </Container>
+  )
 }

--- a/components/topic/TopicPrayerPoints.tsx
+++ b/components/topic/TopicPrayerPoints.tsx
@@ -1,42 +1,46 @@
-import React from "react";
-import { Container, Card } from "react-bootstrap";
-import {FaPrayingHands} from 'react-icons/fa'
-import { IconContext } from "react-icons/lib";
-import { BsDownload } from "react-icons/bs";
+import React from "react"
+import { Container, Card } from "react-bootstrap"
+import { FaPrayingHands } from "react-icons/fa"
+import { IconContext } from "react-icons/lib"
+import { BsDownload } from "react-icons/bs"
 
 interface prayerProps {
-    prayerPoints: string[]
-    title: string
-    subtitle: string
+  prayerPoints: string[]
+  title: string
+  subtitle: string
 }
 
-export default function TopicPrayerPoints({prayerPoints, title, subtitle}:prayerProps) {
-    return (
-        <Container data-testid={"topic-points-container"} className="d-flex justify-content-center px-6" id="topic-prayer">
-            <Card className="my-4 shadow d-lg-flex flex-lg-row">
-                {/* temporary height for video, before we finalize videos */}
-                <Card.Img variant="top" src="/bamboo.jpeg" style={{height:'300px', maxWidth:'600px'}}></Card.Img>
-                <Card.Body style={{maxWidth:'600px'}}>
-                    <Card.Text data-testid={"topic-points-title"} className="px-2 pb-3 fs-2 fst-italic fw-bold border-bottom border-grey d-flex justify-content-between align-items-center">
-                        {title}
-                        <IconContext.Provider value={{size:'30px'}}>
-                            <BsDownload className="text-secondary fw-bold" style={{cursor: 'pointer'}}>
-                            </BsDownload>
-                        </IconContext.Provider>
-                    </Card.Text>
-                    <Card.Text className="d-flex align-items-center gap-2 text-secondary">
-                        <IconContext.Provider value={{size:'20px'}}>
-                            <FaPrayingHands></FaPrayingHands>
-                        </IconContext.Provider>
-                        {subtitle}
-                    </Card.Text>
-                    <ul className="fs-5" data-testid={"topic-points-points"}>
-                        {prayerPoints.map((point:string) => 
-                            <li key={point} className="my-3">{point}</li>
-                        )}
-                    </ul>
-                </Card.Body>
-            </Card>
-        </Container>
-    )
+export default function TopicPrayerPoints({ prayerPoints, title, subtitle }: prayerProps) {
+  return (
+    <Container data-testid={"topic-points-container"} className="d-flex justify-content-center px-6" id="topic-prayer">
+      <Card className="my-4 shadow d-lg-flex flex-lg-row">
+        {/* temporary height for video, before we finalize videos */}
+        <Card.Img variant="top" src="/bamboo.jpeg" style={{ height: "300px", maxWidth: "600px" }}></Card.Img>
+        <Card.Body style={{ maxWidth: "600px" }}>
+          <Card.Text
+            data-testid={"topic-points-title"}
+            className="px-2 pb-3 fs-2 fst-italic fw-bold border-bottom border-grey d-flex justify-content-between align-items-center"
+          >
+            {title}
+            <IconContext.Provider value={{ size: "30px" }}>
+              <BsDownload className="text-secondary fw-bold" style={{ cursor: "pointer" }}></BsDownload>
+            </IconContext.Provider>
+          </Card.Text>
+          <Card.Text className="d-flex align-items-center gap-2 text-secondary">
+            <IconContext.Provider value={{ size: "20px" }}>
+              <FaPrayingHands></FaPrayingHands>
+            </IconContext.Provider>
+            {subtitle}
+          </Card.Text>
+          <ul className="fs-5" data-testid={"topic-points-points"}>
+            {prayerPoints.map((point: string, idx: number) => (
+              <li key={idx + point} className="my-3">
+                {point}
+              </li>
+            ))}
+          </ul>
+        </Card.Body>
+      </Card>
+    </Container>
+  )
 }

--- a/pages/topics/[topicPage].tsx
+++ b/pages/topics/[topicPage].tsx
@@ -1,177 +1,177 @@
-import Head from "next/head";
-import { getTopicPageIds } from "../../services/staticTopicLoader";
-import { GetStaticProps, GetStaticPaths } from "next";
-import { Container } from "react-bootstrap";
-import { ToggleHeader } from "../../components/toggleHeader";
-import TopicDownloadables from "../../components/topic/TopicDownloadables";
-import RelatedContent from "../../components/topic/RelatedContent";
-import Footer from "../../components/footer";
-import { useTranslation } from "next-i18next";
-import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import Feedback from "../../components/topic/Feedback";
-import ImageGroup from "../../components/topic/ImageGroup";
-import { TopicNav } from "../../components/topic/TopicNav";
-import React from "react";
-import PrayerPoints from "../../components/common/PrayerPoints";
+import Head from "next/head"
+import { getTopicPageIds } from "../../services/staticTopicLoader"
+import { GetStaticProps, GetStaticPaths } from "next"
+import { Container } from "react-bootstrap"
+import { ToggleHeader } from "../../components/toggleHeader"
+import TopicDownloadables from "../../components/topic/TopicDownloadables"
+import RelatedContent from "../../components/topic/RelatedContent"
+import Footer from "../../components/footer"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
+import Feedback from "../../components/topic/Feedback"
+import ImageGroup from "../../components/topic/ImageGroup"
+import { TopicNav } from "../../components/topic/TopicNav"
+import React from "react"
+import PrayerPoints from "../../components/common/PrayerPoints"
 
 export const getStaticPaths: GetStaticPaths = async () => {
-    const paths = getTopicPageIds();
+  const paths = getTopicPageIds()
 
-    return {
-        paths,
-        fallback: false,
-    };
-};
+  return {
+    paths,
+    fallback: false,
+  }
+}
 
 export const getStaticProps: GetStaticProps = async ({ params, locale }: any) => {
-    if (!params) {
-        return {
-            props: {},
-        };
-    }
-
-    // const topicId: string = params.topicPage
-    const localeRef: string = "topics/" + params.topicPage;
-
+  if (!params) {
     return {
-        props: {
-            localeRef,
-            ...(await serverSideTranslations(locale, ["common", localeRef])),
-        },
-    };
-};
+      props: {},
+    }
+  }
+
+  // const topicId: string = params.topicPage
+  const localeRef: string = "topics/" + params.topicPage
+
+  return {
+    props: {
+      localeRef,
+      ...(await serverSideTranslations(locale, ["common", localeRef])),
+    },
+  }
+}
 
 export default function TopicPage({ localeRef }: { localeRef: string }) {
-    const { t } = useTranslation(localeRef);
+  const { t } = useTranslation(localeRef)
 
-    // Objects holding translations
-    const summaryPoints: string[] = t("summary.content", { returnObjects: true });
-    const summaryTitle: string = t("summary.title");
+  // Objects holding translations
+  const summaryPoints: string[] = t("summary.content", { returnObjects: true })
+  const summaryTitle: string = t("summary.title")
 
-    const bodyContent1: string[] = t("mainBody.content1", { returnObjects: true });
-    const bodyContent2: string[] = t("mainBody.content2", { returnObjects: true });
-    const bodyContent3: string[] = t("mainBody.content3", { returnObjects: true });
+  const bodyContent1: string[] = t("mainBody.content1", { returnObjects: true })
+  const bodyContent2: string[] = t("mainBody.content2", { returnObjects: true })
+  const bodyContent3: string[] = t("mainBody.content3", { returnObjects: true })
 
-    const quoteContent: string = t("quote.content");
-    const quoteSource: string = t("quote.source");
+  const quoteContent: string = t("quote.content")
+  const quoteSource: string = t("quote.source")
 
-    const dykTitle: string = t("didYouKnow.title");
-    const dykContent: string = t("didYouKnow.content");
+  const dykTitle: string = t("didYouKnow.title")
+  const dykContent: string = t("didYouKnow.content")
 
-    const prayerTitle: string = t("prayerPoints.title");
-    const prayerSub: string = t("prayerPoints.subtitle");
+  const prayerTitle: string = t("prayerPoints.title")
+  const prayerSub: string = t("prayerPoints.subtitle")
 
-    const feedbackTitle: string = t("feedback.title");
-    const feedbackButton: string = t("feedback.button");
+  const feedbackTitle: string = t("feedback.title")
+  const feedbackButton: string = t("feedback.button")
 
-    const downloadsTitle: string = t("downloads.title");
-    const downloadsLabels: string[] = t("downloads.labels", { returnObjects: true });
-    const downloadsLinks: string[] = t("downloads.links", { returnObjects: true });
-    const downloadsHeaders: string[] = t("downloads.headers", { returnObjects: true });
+  const downloadsTitle: string = t("downloads.title")
+  const downloadsLabels: string[] = t("downloads.labels", { returnObjects: true })
+  const downloadsLinks: string[] = t("downloads.links", { returnObjects: true })
+  const downloadsHeaders: string[] = t("downloads.headers", { returnObjects: true })
 
-    const relatedTitle: string = t("related.title");
-    const relatedLabels: string[] = t("related.labels", { returnObjects: true });
-    const relatedLinks: string[] = t("related.links", { returnObjects: true });
+  const relatedTitle: string = t("related.title")
+  const relatedLabels: string[] = t("related.labels", { returnObjects: true })
+  const relatedLinks: string[] = t("related.links", { returnObjects: true })
 
-    const navLabels: string[] = t("topicNav.labels", { returnObjects: true });
+  const navLabels: string[] = t("topicNav.labels", { returnObjects: true })
 
-    const pageTitle: string = t("title");
+  const pageTitle: string = t("title")
 
-    // States
-    const [selected, setSelected] = React.useState<string>("About");
+  // States
+  const [selected, setSelected] = React.useState<string>("About")
 
-    return (
-        <>
-            <Head>
-                <title>{pageTitle}</title>
-                <meta name="description" content="Japan prayer guide" />
-                <meta name="viewport" content="width=device-width, initial-scale=1" />
-                <link rel="icon" href="/favicon.ico" />
-            </Head>
-            <main>
-                {/* Header Component */}
-                <ToggleHeader />
+  return (
+    <>
+      <Head>
+        <title>{pageTitle}</title>
+        <meta name="description" content="Japan prayer guide" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <main>
+        {/* Header Component */}
+        <ToggleHeader />
 
-                {/* Component to Hold image, as well as title and Prayer Summary */}
-                <div id="placeholder-image" className="w-100 mx-0 px-0 position-relative" style={{ height: "700px" }}>
-                    temporary image placeholder
-                    <Container className="d-flex flex-column align-items-start justify-content-end h-100 py-5">
-                        <h1 className="fs-1 text-white px-3">{t("title")}</h1>
-                        <PrayerPoints prayerPoints={summaryPoints} title={summaryTitle} />
-                    </Container>
-                </div>
+        {/* Component to Hold image, as well as title and Prayer Summary */}
+        <div id="placeholder-image" className="w-100 mx-0 px-0 position-relative" style={{ height: "700px" }}>
+          temporary image placeholder
+          <Container className="d-flex flex-column align-items-start justify-content-end h-100 py-5">
+            <h1 className="fs-1 text-white px-3">{t("title")}</h1>
+            <PrayerPoints prayerPoints={summaryPoints} title={summaryTitle} />
+          </Container>
+        </div>
 
-                {/* Topic Nav Component */}
-                <TopicNav selected={selected} setSelected={setSelected} labels={navLabels} />
+        {/* Topic Nav Component */}
+        <TopicNav selected={selected} setSelected={setSelected} labels={navLabels} />
 
-                {/* Video/Reel Placeholder */}
-                <Container className="py-5" id="topic-about">
-                    <div id="placeholder-image" className="w-100">
-                        Video Placeholder
-                    </div>
-                </Container>
+        {/* Video/Reel Placeholder */}
+        <Container className="py-5" id="topic-about">
+          <div id="placeholder-image" className="w-100">
+            Video Placeholder
+          </div>
+        </Container>
 
-                {/* Placeholder text */}
-                <Container className="py-5">
-                    {bodyContent1.map((text) => (
-                        <p key={text}>{text}</p>
-                    ))}
-                </Container>
+        {/* Placeholder text */}
+        <Container className="py-5">
+          {bodyContent1.map((text: string, idx: number) => (
+            <p key={idx + text}>{text}</p>
+          ))}
+        </Container>
 
-                {/* Image Grid */}
-                <ImageGroup />
+        {/* Image Grid */}
+        <ImageGroup />
 
-                {/* Placeholder text */}
-                <Container className="py-5">
-                    {bodyContent2.map((text) => (
-                        <p key={text}>{text}</p>
-                    ))}
-                </Container>
+        {/* Placeholder text */}
+        <Container className="py-5">
+          {bodyContent2.map((text: string, idx: number) => (
+            <p key={idx + text}>{text}</p>
+          ))}
+        </Container>
 
-                {/* Infographics Placeholder */}
-                <Container>
-                    <div id="placeholder-image" className="w-100">
-                        Infographics Placeholder
-                    </div>
-                </Container>
+        {/* Infographics Placeholder */}
+        <Container>
+          <div id="placeholder-image" className="w-100">
+            Infographics Placeholder
+          </div>
+        </Container>
 
-                {/* Placeholder for a quote */}
-                <Container className="d-flex flex-column justify-content-center align-items-center py-4 my-4">
-                    <h1 className="text-secondary fs-1 text-center">{quoteContent}</h1>
-                    <h2 className="text-secondary fs-6 text-center">{quoteSource}</h2>
-                </Container>
+        {/* Placeholder for a quote */}
+        <Container className="d-flex flex-column justify-content-center align-items-center py-4 my-4">
+          <h1 className="text-secondary fs-1 text-center">{quoteContent}</h1>
+          <h2 className="text-secondary fs-6 text-center">{quoteSource}</h2>
+        </Container>
 
-                {/* Placeholder Image */}
-                <div id="placeholder-image" className="w-100 my-5">
-                    Placeholder
-                </div>
+        {/* Placeholder Image */}
+        <div id="placeholder-image" className="w-100 my-5">
+          Placeholder
+        </div>
 
-                {/* Placeholder text */}
-                <Container className="py-5">
-                    {bodyContent3.map((text) => (
-                        <p key={text}>{text}</p>
-                    ))}
-                </Container>
+        {/* Placeholder text */}
+        <Container className="py-5">
+          {bodyContent3.map((text: string, idx: number) => (
+            <p key={idx + text}>{text}</p>
+          ))}
+        </Container>
 
-                {/* Prayer Points */}
-                <PrayerPoints prayerPoints={summaryPoints} title={prayerTitle} showImg={true} showSubtitle={true} />
-                <br />
+        {/* Prayer Points */}
+        <PrayerPoints prayerPoints={summaryPoints} title={prayerTitle} showImg={true} showSubtitle={true} />
+        <br />
 
-                {/* Give us Feedback */}
-                <Feedback title={feedbackTitle} button={feedbackButton} />
+        {/* Give us Feedback */}
+        <Feedback title={feedbackTitle} button={feedbackButton} />
 
-                {/* Downloads and Related */}
-                <TopicDownloadables
-                    links={downloadsLinks}
-                    labels={downloadsLabels}
-                    title={downloadsTitle}
-                    headers={downloadsHeaders}
-                />
-                <RelatedContent topics={relatedLabels} links={relatedLinks} title={relatedTitle} />
+        {/* Downloads and Related */}
+        <TopicDownloadables
+          links={downloadsLinks}
+          labels={downloadsLabels}
+          title={downloadsTitle}
+          headers={downloadsHeaders}
+        />
+        <RelatedContent topics={relatedLabels} links={relatedLinks} title={relatedTitle} />
 
-                {/* Footer */}
-                <Footer />
-            </main>
-        </>
-    );
+        {/* Footer */}
+        <Footer />
+      </main>
+    </>
+  )
 }


### PR DESCRIPTION
This change adds index as a prefix for the 'key' property for most of our maps - this is normally not suggested as it interferes with React's optimizations for list insertions / removals, but in our case we always want to be replacing the whole list since it only occurs on language change.

Note that this is also unlikely to occur to begin with, as it'll only happen when there is a duplicate key (i.e, the same text repeated within an array of text content) which _shouldn't_ occur with the proper copy