### PR TITLE
allow user scrolling to update active navlink

### DIFF
--- a/components/topic-overview/TopicOverviewNav.tsx
+++ b/components/topic-overview/TopicOverviewNav.tsx
@@ -7,13 +7,35 @@ interface Props {
   setSelected: Dispatch<SetStateAction<string>>
 }
 
-const scrollOffset = -50 // Adjust this value to the desired scroll height
+const scrollOffset = -50
 
 export const TopicOverviewNav = ({ selected, setSelected }: Props) => {
   const { t } = useTranslation("topic-overview")
 
   const bannerRef = useRef(null)
   const [show, setShow] = useState(false)
+  const isScrolling = useRef(false)
+
+  const highlightCurrentNavLink = () => {
+    // If we're not in the 'church' section, show 'culture' as selected by default
+    const scrollY = window.scrollY
+
+    const churchSection = document.getElementById("church")
+
+    if (churchSection) {
+      // The leeway makes it so that if they click the link and scroll a little, it will still show the correct section as selected
+      const scrollLeeway = 10
+      const churchPosition =
+        churchSection.getBoundingClientRect().top + window.pageYOffset + scrollOffset - scrollLeeway
+
+      // Determine which section is active based on the scroll position
+      if (scrollY >= churchPosition) {
+        setSelected("church")
+      } else {
+        setSelected("culture")
+      }
+    }
+  }
 
   useEffect(() => {
     const handleScroll = () => {
@@ -26,7 +48,12 @@ export const TopicOverviewNav = ({ selected, setSelected }: Props) => {
           setShow(false)
         }
       }
+
+      if (!isScrolling.current) {
+        highlightCurrentNavLink()
+      }
     }
+
     window.addEventListener("scroll", handleScroll)
     return () => {
       window.removeEventListener("scroll", handleScroll)
@@ -35,12 +62,16 @@ export const TopicOverviewNav = ({ selected, setSelected }: Props) => {
 
   const scrollToCustomPosition = (id: string) => {
     setSelected(id)
+    isScrolling.current = true // block the listener from triggering while we scroll
     const targetElement = document.getElementById(id)
-    const offset = -50 // Adjust this value to the desired scroll height
 
     if (targetElement) {
       const topPosition = targetElement.getBoundingClientRect().top
-      window.scrollTo({ top: topPosition + window.pageYOffset + offset, behavior: "smooth" })
+      window.scrollTo({ top: topPosition + window.pageYOffset + scrollOffset, behavior: "smooth" })
+
+      setTimeout(() => {
+        isScrolling.current = false
+      }, 1500)
     }
   }
 
@@ -77,6 +108,7 @@ export const TopicOverviewNav = ({ selected, setSelected }: Props) => {
                 : " text-black")
             }
             onClick={() => scrollToCustomPosition("church")}
+            data-testid="overview-nav-link-2"
           >
             {t("botHeading")}
           </a>

--- a/test/components/Topic-Overview/TopicOverviewNav.test.tsx
+++ b/test/components/Topic-Overview/TopicOverviewNav.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import { TopicOverviewNav } from "../../../components/topic-overview/TopicOverviewNav"
-import React from "react"
+import React, { useState } from "react"
 
 jest.mock("next/router", () => ({
   useRouter: jest.fn(),
@@ -29,5 +29,35 @@ describe("Overview Nav", () => {
     const navContainer = screen.getByTestId("overview-nav-container")
 
     expect(navContainer).toHaveClass("sticky-top")
+  })
+})
+
+const TestComponent = () => {
+  const [selected, setSelected] = useState("culture")
+
+  return (
+    <>
+      <TopicOverviewNav selected={selected} setSelected={setSelected} />
+      <div id="culture"></div>
+      <div id="church"></div>
+    </>
+  )
+}
+
+describe("Overview Nav - scrolling behavior", () => {
+  test("scrolling to a section activates the relevant nav link", () => {
+    render(<TestComponent />)
+
+    const topNavLink = screen.getByTestId("overview-nav-link")
+    const botNavLink = screen.getByTestId("overview-nav-link-2")
+    expect(topNavLink).toHaveClass("fw-bold")
+    expect(botNavLink).toHaveClass("text-black")
+
+    // Simulate scrolling to the bottom 'church' section, note this number only corresponds to the test
+    window.scrollY = 2600
+    fireEvent.scroll(window)
+
+    expect(topNavLink).toHaveClass("text-black")
+    expect(botNavLink).toHaveClass("fw-bold")
   })
 })


### PR DESCRIPTION
This PR will make it so that 

- when the user scrolls to a section, that section's nav link will be set as active.

- If the user clicks on a nav-link to scroll to a section, the above behaviour will be blocked for 1500ms (which will prevent the active link switching back **whilst** the nav link is scrolling them to the right section, or if the user scrolls a little bit up/down right after they've clicked the nav link)

It may just be my pc, but I had some 'flickering' with active nav links during scrolling when trying a lower timeout.

Note that if anyone can help me write a test for the 2nd point, it would be greatly appreciated