### PR TITLE
fixed the overlay on the gallery, as well as 2x2 for mobile again

### DIFF
--- a/components/GalleryComponents/NestedModal/NestedModal.tsx
+++ b/components/GalleryComponents/NestedModal/NestedModal.tsx
@@ -44,7 +44,7 @@ export const NestedModal = ({ images, subTitle, galleryTitle, imageText }: Neste
         <div>
             <div className="container" style={{ marginTop: "12px" }}>
                 <p className="gallerySubtitle">{subTitle}</p>
-                <Row className="galleryContainer" xl={4} sm={2} md={2}>
+                <Row className="galleryContainer" xl={4} sm={2} md={2} xs={2}>
                     {[...images].splice(0, 4).map((item, index) => {
                         if (index !== 3) {
                             return (

--- a/styles/components.scss
+++ b/styles/components.scss
@@ -163,6 +163,13 @@
     &:hover {
         opacity: 0.2;
     }
+    @include media-breakpoint-down(md) {
+        top: 3px;
+        left: 3px;
+        height: calc(100% - 6px);
+        width: calc(100% - 6px);
+        margin: 0;
+    }
 }
 
 .galleryMoreOverlay {
@@ -181,6 +188,13 @@
     margin: 10px 10px;
     &:hover {
         opacity: 0.9;
+    }
+    @include media-breakpoint-down(md) {
+        top: 3px;
+        left: 3px;
+        height: calc(100% - 6px);
+        width: calc(100% - 6px);
+        margin: 0;
     }
     .galleryMoreNumber {
         color: white;


### PR DESCRIPTION
**What**
Fixed two things:
1) the +16 overlay as well as the "darken when hovering" was not overlayed correctly on small viewpoints. Fixed
2) Images are supposed to be 2x2 on the topic page itself for the gallery preview, so this was fixed as well on small screens.